### PR TITLE
feat: apply strikethrough on previous tasks in navigation

### DIFF
--- a/tasks/2/README.md
+++ b/tasks/2/README.md
@@ -3,7 +3,7 @@
 <details>
 <summary>Navigation</summary>
 
-1. [Creating a workflow](../1/README.md)
+1. ~~[Creating a workflow](../1/README.md)~~
 2. **Building code in a workflow** (this task)
 3. [Running multiple jobs in parallel](../3/README.md)
 4. [Running jobs in sequence](../4/README.md)

--- a/tasks/3/README.md
+++ b/tasks/3/README.md
@@ -3,8 +3,8 @@
 <details>
 <summary>Navigation</summary>
 
-1. [Creating a workflow](../1/README.md)
-2. [Building code in a workflow](../2/README.md)
+1. ~~[Creating a workflow](../1/README.md)~~
+2. ~~[Building code in a workflow](../2/README.md)~~
 3. **Running multiple jobs in parallel** (this task)
 4. [Running jobs in sequence](../4/README.md)
 5. [Deploying to GitHub Pages](../5/README.md)

--- a/tasks/4/README.md
+++ b/tasks/4/README.md
@@ -3,9 +3,9 @@
 <details>
 <summary>Navigation</summary>
 
-1. [Creating a workflow](../1/README.md)
-2. [Building code in a workflow](../2/README.md)
-3. [Running multiple jobs in parallel](../3/README.md)
+1. ~~[Creating a workflow](../1/README.md)~~
+2. ~~[Building code in a workflow](../2/README.md)~~
+3. ~~[Running multiple jobs in parallel](../3/README.md)~~
 4. **Running jobs in sequence** (this task)
 5. [Deploying to GitHub Pages](../5/README.md)
 6. [Using other events to run workflows](../6/README.md)

--- a/tasks/5/README.md
+++ b/tasks/5/README.md
@@ -3,10 +3,10 @@
 <details>
 <summary>Navigation</summary>
 
-1. [Creating a workflow](../1/README.md)
-2. [Building code in a workflow](../2/README.md)
-3. [Running multiple jobs in parallel](../3/README.md)
-4. [Running jobs in sequence](../4/README.md)
+1. ~~[Creating a workflow](../1/README.md)~~
+2. ~~[Building code in a workflow](../2/README.md)~~
+3. ~~[Running multiple jobs in parallel](../3/README.md)~~
+4. ~~[Running jobs in sequence](../4/README.md)~~
 5. **Deploying to GitHub Pages** (this task)
 6. [Using other events to run workflows](../6/README.md)
 

--- a/tasks/6/README.md
+++ b/tasks/6/README.md
@@ -3,11 +3,11 @@
 <details>
 <summary>Navigation</summary>
 
-1. [Creating a workflow](../1/README.md)
-2. [Building code in a workflow](../2/README.md)
-3. [Running multiple jobs in parallel](../3/README.md)
-4. [Running jobs in sequence](../4/README.md)
-5. [Deploying to GitHub Pages](../5/README.md)
+1. ~~[Creating a workflow](../1/README.md)~~
+2. ~~[Building code in a workflow](../2/README.md)~~
+3. ~~[Running multiple jobs in parallel](../3/README.md)~~
+4. ~~[Running jobs in sequence](../4/README.md)~~
+5. ~~[Deploying to GitHub Pages](../5/README.md)~~
 6. **Using other events to run workflows** (this task)
 
 </details>


### PR DESCRIPTION
This PR adds strikethroughs to previous navigation elements in the task navigation. I think it will give some sense of completion when going through the tasks, but it might be annoying?

<img width="515" alt="image" src="https://github.com/Tietoevry-Create/gh-actions-workshop/assets/9085189/657cae10-fc56-498d-972c-b09eb27a87d4">
